### PR TITLE
[Fix] Triggering deploys from WordPress mobile apps

### DIFF
--- a/includes/auto-deploy.php
+++ b/includes/auto-deploy.php
@@ -25,7 +25,7 @@ if ( ! empty( get_option( 'netlifypress_build_hook_url' ) ) && get_option( 'netl
 
     add_action( 'init', 'netlifypress_auto_deploy_initialize' );
     function netlifypress_auto_deploy_initialize() {
-        if ( current_user_can( 'manage_options' ) && ( in_array( 'publish', get_option( 'netlifypress_action_auto_deploy' ) ) || in_array( 'update', get_option( 'netlifypress_action_auto_deploy' ) ) || in_array( 'trash', get_option( 'netlifypress_action_auto_deploy' ) ) ) ) {
+        if ( ( in_array( 'publish', get_option( 'netlifypress_action_auto_deploy' ) ) || in_array( 'update', get_option( 'netlifypress_action_auto_deploy' ) ) || in_array( 'trash', get_option( 'netlifypress_action_auto_deploy' ) ) ) ) {
             add_action( 'save_post', 'netlifypress_deploy_trigger', 10, 2 );
         }
     }


### PR DESCRIPTION
## Description
This PR fixes #1 where @sahandnayebaziz reported that edits from WordPress mobile apps were not being triggered.

## Cause
Before the deploy trigger action was fired with the `save_post` hook, we're currently doing a user role check to make sure the current user is an admin. For some reason, that user check is failing on the mobile apps (we're exactly not sure why as I don't have much knowledge about the WordPress mobile apps and the XML-RPC API).

## Solution
Upon further considerations, we realized that the user role check is not really necessary here as users without the admin role can also publish/edit posts (e.g. editor, author). As a result, we've removed the user role check in this and according to my tests and of @sahandnayebaziz, triggers from the mobile apps are now working.

⭐️Special props to @sahandnayebaziz for reporting this issue and for testing the solution.